### PR TITLE
Fix php version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^7.2"
+        "php": ">=7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2"
+        "php": "^7.2 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
I'm not sure how to specify it better: `>=7.2` or `^7.2 | ^8.0` or `>=7.2 <9`.
`>=7.2` looks OK for me now.